### PR TITLE
Include `add_filter` Call in Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ The rules for anonymization can be extended using the `wpmdb_anonymization_confi
 
         return $config;
     }
+    
+    add_filter( 'wpmdb_anonymization_config', 'my_wpmdb_anonymization_rules' );


### PR DESCRIPTION
This is a fairly trivial tweak, since most folks reading this will be devs who—especially in the context of the demo code block's preceding content—will know how to hook up this callback to the filter.

Still, from an OCD level I just wanted to complete the code block. This tweak will do that, and will ensure it matches the example in the [stellar accompanying blog post](https://deliciousbrains.com/gdpr-local-development/).