### PR TITLE
Use strrpos instead strpos in user whitelist example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also programmatically control which users are whitelisted with the follo
      * @return bool
      */
     function my_wpmdb_anonymization_user_whitelisted( $whitelisted, $user )  {
-        if ( false !== strpos( $user->user_email, '@somedomain.com' ) ) {
+        if ( false !== strrpos( $user->user_email, '@somedomain.com' ) ) {
             // All users with the login containing an email address of somedomain.com are whitelisted
             return true;
         }


### PR DESCRIPTION
Since the domain is an email's last part, [`strrpos()`](https://www.php.net/manual/en/function.strrpos.php) should be used to search the domain substring in the user email.