### PR TITLE
Satisfy a warning generated from updating to PHP8

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -122,6 +122,6 @@ class Plugin {
 	/**
 	 * As this class is a singleton it should not be able to be unserialized
 	 */
-	protected function __wakeup() {
+	public function __wakeup() {
 	}
 }


### PR DESCRIPTION
![2022-01-18_10-12](https://user-images.githubusercontent.com/12238901/149917309-42c256d8-9f49-498c-8c64-b87c3a2829fc.png)

We are looking at updating our infrastructure to PHP8. When starting up our starter theme with PHP it throws a warning :

```
Warning: The magic method WPMDB\Anonymization\Plugin::__wakeup() must have public visibility in /srv/www/brickblocks/public/content/plugins/wp-migrate-db-anonymization/includes/Plugin.php on line 125 
```

Looking at the code, this method doesn't appear to do anything an is empty. I don't pretend to understand why these empty functions are a) present or b) set to protected (when they are not being used).

Would setting this one to public be a viable solution to this warning?

Always happy to learn!